### PR TITLE
feat: Add test coverage for budget components

### DIFF
--- a/tests/components/budget/BudgetDashboard.test.tsx
+++ b/tests/components/budget/BudgetDashboard.test.tsx
@@ -1,0 +1,221 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BudgetDashboard from '@/components/budget/BudgetDashboard';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Trip, Expense, BudgetCategory } from '@/types';
+
+// Polyfill for Radix UI components in JSDOM
+if (typeof Element.prototype.scrollIntoView === 'undefined') {
+  Element.prototype.scrollIntoView = vi.fn();
+}
+if (typeof Element.prototype.hasPointerCapture === 'undefined') {
+  Element.prototype.hasPointerCapture = vi.fn(() => false);
+}
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+// Mock child components
+vi.mock('@/components/budget/BudgetSummary', () => ({
+  __esModule: true,
+  default: () => <div data-testid="budget-summary-widget" />,
+}));
+
+const mockAddedExpense: Expense = { id: 'exp-new', trip_id: 'trip1', amount: 10, currency: 'USD', description: 'New Snack', category_id: 'cat1', is_prepaid: false, expense_date: '2024-01-04T10:00:00Z', amount_in_home_currency: 10, fx_rate: 1, fx_source: 'live' };
+
+vi.mock('@/components/budget/QuickAddExpense', () => ({
+    __esModule: true,
+    default: ({ onAdded }: { onAdded: (e: Expense) => void }) => (
+      <button data-testid="quick-add-expense" onClick={() => onAdded(mockAddedExpense)}>
+        Add Expense
+      </button>
+    ),
+  }));
+vi.mock('@/components/budget/CategoryManagement', () => ({
+  __esModule: true,
+  default: () => <div data-testid="category-management" />,
+}));
+vi.mock('@/components/budget/BudgetPostTripReport', () => ({
+    __esModule: true,
+    default: () => <div data-testid="budget-post-trip-report" />,
+}));
+
+
+// Mock fetch
+global.fetch = vi.fn();
+
+const mockTrip: Trip = {
+  id: 'trip1',
+  user_id: 'user1',
+  title: 'Test Trip',
+  destination: 'Testville',
+  start_date: '2024-01-01',
+  end_date: '2024-01-10',
+  currency: 'USD',
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+const mockCategories: BudgetCategory[] = [
+    { id: 'cat1', name: 'Food', trip_id: 'trip1', user_id: 'user1' },
+    { id: 'cat2', name: 'Transport', trip_id: 'trip1', user_id: 'user1' },
+];
+
+const mockExpenses: Expense[] = [
+  { id: 'exp1', trip_id: 'trip1', amount: 100, currency: 'USD', description: 'Dinner', category: mockCategories[0], is_prepaid: false, expense_date: '2024-01-02T19:00:00Z', amount_in_home_currency: 100, fx_rate: 1, fx_source: 'live' },
+  { id: 'exp2', trip_id: 'trip1', amount: 50, currency: 'USD', description: 'Taxi', category: mockCategories[1], is_prepaid: true, expense_date: '2024-01-02T12:00:00Z', amount_in_home_currency: 50, fx_rate: 1, fx_source: 'live' },
+  { id: 'exp3', trip_id: 'trip1', amount: 25, currency: 'EUR', description: 'Coffee', category: mockCategories[0], is_prepaid: false, expense_date: '2024-01-03T09:00:00Z', amount_in_home_currency: 30, fx_rate: 1.2, fx_source: 'live' },
+];
+
+const mockDict = {
+  budget: {
+    dashboard: {
+      title: 'Budget Dashboard',
+      confirmDeleteExpense: 'Delete this expense?',
+      modes: { simple: 'On-Trip', full: 'Full' },
+      filters: { all: 'All', excludePrepaid: 'Exclude Prepaid', onlyPrepaid: 'Only Prepaid' },
+      refresh: { action: 'Refresh', refreshing: 'Refreshing...' },
+      expenses: { heading: 'Expenses', empty: 'No expenses yet.', fallbackTitle: 'Expense', prepaidBadge: 'Prepaid' },
+    },
+    errors: {
+        loadExpenses: 'Failed to load expenses',
+        deleteFailed: 'Delete failed',
+    }
+  },
+};
+
+vi.mock('@/lib/i18n', () => ({
+  getDictionary: () => mockDict,
+}));
+
+describe('BudgetDashboard', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (fetch as vi.Mock).mockClear();
+    window.confirm = vi.fn(() => true);
+    (fetch as vi.Mock).mockImplementation((url, options) => {
+        if (url.toString().includes('expenses') && options?.method === 'DELETE') {
+            return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+        }
+        if (url.toString().includes('expenses')) {
+            return Promise.resolve({ ok: true, json: () => Promise.resolve({ expenses: mockExpenses }) });
+        }
+        return Promise.reject(new Error(`Unhandled fetch: ${url}`));
+    });
+  });
+
+  it('fetches and displays expenses on initial render (in default "On-Trip" mode)', async () => {
+    render(<BudgetDashboard trip={mockTrip} lang="en" />);
+
+    // Initially, only non-prepaid expenses should be visible
+    expect(await screen.findByText('Dinner')).toBeInTheDocument();
+    expect(screen.getByText('Coffee')).toBeInTheDocument();
+    expect(screen.queryByText('Taxi')).not.toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledWith(`/api/trips/${mockTrip.id}/expenses`);
+  });
+
+  it('shows a loading state initially and then removes it', async () => {
+    render(<BudgetDashboard trip={mockTrip} lang="en" />);
+    // The loading skeleton is a UL with specific styling. It's the only list initially.
+    const skeletonList = screen.getByRole('list');
+    expect(skeletonList).toHaveClass('animate-pulse');
+
+    // Wait for the final content to appear
+    await waitFor(() => {
+      expect(screen.getByText('Dinner')).toBeInTheDocument();
+    });
+
+    // After loading, check that the lists no longer have the pulse class.
+    const finalLists = screen.getAllByRole('list');
+    expect(finalLists.length).toBe(2); // Two lists, one for each day
+    finalLists.forEach(list => {
+      expect(list).not.toHaveClass('animate-pulse');
+    });
+  });
+
+  it('shows an error message if fetching expenses fails', async () => {
+    (fetch as vi.Mock).mockImplementationOnce(() => Promise.resolve({ ok: false }));
+    render(<BudgetDashboard trip={mockTrip} lang="en" />);
+    expect(await screen.findByText(mockDict.budget.errors.loadExpenses)).toBeInTheDocument();
+  });
+
+  it('filters expenses based on budget mode and prepaid status', async () => {
+    render(<BudgetDashboard trip={mockTrip} lang="en" />);
+
+    await waitFor(() => expect(screen.queryByText('Dinner')).toBeInTheDocument());
+
+    // Default "On-Trip" (simple) mode should exclude prepaid
+    expect(screen.queryByText('Taxi')).not.toBeInTheDocument();
+
+    // Switch to "Full" mode
+    const fullModeButton = screen.getByRole('button', { name: 'Full' });
+    await user.click(fullModeButton);
+
+    // "All" filter is default for "Full" mode, so Taxi should now be visible
+    expect(await screen.findByText('Taxi')).toBeInTheDocument();
+    expect(screen.getByText('Dinner')).toBeInTheDocument();
+
+    // Filter to "Only Prepaid"
+    const onlyPrepaidButton = screen.getByRole('button', { name: 'Only Prepaid' });
+    await user.click(onlyPrepaidButton);
+    expect(screen.queryByText('Dinner')).not.toBeInTheDocument();
+    expect(screen.getByText('Taxi')).toBeInTheDocument();
+
+    // Filter to "Exclude Prepaid"
+    const excludePrepaidButton = screen.getByRole('button', { name: 'Exclude Prepaid' });
+    await user.click(excludePrepaidButton);
+    expect(screen.getByText('Dinner')).toBeInTheDocument();
+    expect(screen.queryByText('Taxi')).not.toBeInTheDocument();
+  });
+
+  it('deletes an expense when delete button is clicked', async () => {
+    render(<BudgetDashboard trip={mockTrip} lang="en" />);
+
+    const dinnerExpense = await screen.findByText('Dinner');
+    const expenseItem = dinnerExpense.closest('li');
+    expect(expenseItem).not.toBeNull();
+
+    const deleteButton = expenseItem!.querySelector('button[aria-label="Delete expense"]');
+    expect(deleteButton).not.toBeNull();
+
+    await user.hover(expenseItem!);
+    await user.click(deleteButton!);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(`/api/trips/${mockTrip.id}/expenses/exp1`, { method: 'DELETE' });
+      expect(screen.queryByText('Dinner')).not.toBeInTheDocument();
+    });
+  });
+
+  it('re-fetches expenses on manual refresh', async () => {
+    render(<BudgetDashboard trip={mockTrip} lang="en" />);
+
+    await waitFor(() => expect(screen.queryByText('Dinner')).toBeInTheDocument());
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    const refreshButton = screen.getByRole('button', { name: mockDict.budget.dashboard.refresh.action });
+    await user.click(refreshButton);
+
+    await waitFor(() => {
+        expect(fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('optimistically adds a new expense via QuickAddExpense', async () => {
+    render(<BudgetDashboard trip={mockTrip} lang="en" />);
+
+    await waitFor(() => expect(screen.queryByText('Dinner')).toBeInTheDocument());
+    expect(screen.queryByText('New Snack')).not.toBeInTheDocument();
+
+    const addButton = screen.getByTestId('quick-add-expense');
+    await user.click(addButton);
+
+    await waitFor(() => {
+        expect(screen.getByText('New Snack')).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/components/budget/QuickAddExpense.test.tsx
+++ b/tests/components/budget/QuickAddExpense.test.tsx
@@ -1,0 +1,192 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import QuickAddExpense from '@/components/budget/QuickAddExpense';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BudgetCategory, Expense } from '@/types';
+
+// Polyfill for Radix UI components in JSDOM
+if (typeof Element.prototype.scrollIntoView === 'undefined') {
+  Element.prototype.scrollIntoView = vi.fn();
+}
+if (typeof Element.prototype.hasPointerCapture === 'undefined') {
+  Element.prototype.hasPointerCapture = vi.fn(() => false);
+}
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+// Mock fetch
+global.fetch = vi.fn();
+
+const mockCategories: BudgetCategory[] = [
+  { id: 'cat1', name: 'Food', trip_id: 'trip1', user_id: 'user1' },
+  { id: 'cat2', name: 'Transport', trip_id: 'trip1', user_id: 'user1' },
+];
+
+const mockDict = {
+  budget: {
+    quickAdd: {
+      fabAria: 'Add Expense',
+      title: 'Add New Expense',
+      amount: 'Amount',
+      currency: 'Currency',
+      category: 'Category',
+      selectCategory: 'Select a category',
+      loadingCats: 'Loading categories...',
+      description: 'Description',
+      prepaid: 'This is a prepaid expense',
+      submit: 'Add Expense',
+      adding: 'Adding...',
+    },
+  },
+};
+
+// Mock i18n
+vi.mock('@/lib/i18n', () => ({
+  getDictionary: () => mockDict,
+}));
+
+describe('QuickAddExpense', () => {
+  const user = userEvent.setup();
+  const onAdded = vi.fn();
+  const tripId = 'trip1';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (fetch as vi.Mock).mockClear();
+  });
+
+  it('renders the trigger button and opens the dialog on click', async () => {
+    render(<QuickAddExpense tripId={tripId} onAdded={onAdded} lang="en" buttonVariant="inline" />);
+
+    const triggerButton = screen.getByRole('button', { name: mockDict.budget.quickAdd.submit });
+    expect(triggerButton).toBeInTheDocument();
+
+    await user.click(triggerButton);
+
+    expect(await screen.findByText(mockDict.budget.quickAdd.title)).toBeInTheDocument();
+    expect(screen.getByLabelText(mockDict.budget.quickAdd.amount)).toBeInTheDocument();
+  });
+
+  it('fetches and displays budget categories when dialog opens', async () => {
+    (fetch as vi.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ categories: mockCategories }),
+    });
+
+    render(<QuickAddExpense tripId={tripId} onAdded={onAdded} lang="en" buttonVariant="inline" />);
+    await user.click(screen.getByRole('button', { name: mockDict.budget.quickAdd.submit }));
+
+    expect(fetch).toHaveBeenCalledWith(`/api/trips/${tripId}/budget/categories`);
+
+    const categorySelect = screen.getByRole('combobox');
+    await user.click(categorySelect);
+
+    await waitFor(() => {
+      expect(screen.getByText('Food')).toBeInTheDocument();
+      expect(screen.getByText('Transport')).toBeInTheDocument();
+    });
+  });
+
+  it('allows filling the form and submits the data correctly', async () => {
+    const newExpense: Expense = {
+      id: 'exp1',
+      trip_id: tripId,
+      amount: 12.34,
+      currency: 'USD',
+      description: 'Lunch',
+      category_id: 'cat1',
+      is_prepaid: true,
+      expense_date: new Date().toISOString(),
+    };
+
+    (fetch as vi.Mock).mockImplementation((url: string) => {
+      if (url.includes('categories')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ categories: mockCategories }),
+        });
+      }
+      if (url.includes('expenses')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ expense: newExpense }),
+        });
+      }
+      return Promise.reject(new Error('Unknown fetch call'));
+    });
+
+    render(<QuickAddExpense tripId={tripId} onAdded={onAdded} lang="en" buttonVariant="inline" />);
+    await user.click(screen.getByRole('button', { name: mockDict.budget.quickAdd.submit }));
+
+    // Fill form
+    await user.type(screen.getByLabelText(mockDict.budget.quickAdd.amount), '12.34');
+    await user.clear(screen.getByLabelText(mockDict.budget.quickAdd.currency));
+    await user.type(screen.getByLabelText(mockDict.budget.quickAdd.currency), 'USD');
+    await user.type(screen.getByLabelText(mockDict.budget.quickAdd.description), 'Lunch');
+    await user.click(screen.getByLabelText(mockDict.budget.quickAdd.prepaid));
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(await screen.findByText('Food'));
+
+    // Submit
+    const submitButton = screen.getByRole('button', { name: mockDict.budget.quickAdd.submit });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+        expect(fetch).toHaveBeenCalledWith(`/api/trips/${tripId}/expenses`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                amount: 12.34,
+                currency: 'USD',
+                description: 'Lunch',
+                category_id: 'cat1',
+                is_prepaid: true,
+            }),
+        });
+    });
+
+    expect(onAdded).toHaveBeenCalledWith(newExpense);
+    await waitFor(() => {
+        expect(screen.queryByText(mockDict.budget.quickAdd.title)).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows an error message if submission fails', async () => {
+    (fetch as vi.Mock).mockImplementation((url: string, options) => {
+      if (url.toString().includes('categories')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ categories: mockCategories }) });
+      }
+      if (url.toString().includes('expenses') && options?.method === 'POST') {
+        return Promise.resolve({ ok: false, json: () => Promise.resolve({ error: 'Failed to add expense' }) });
+      }
+      return Promise.reject(new Error(`Unhandled fetch: ${url}`));
+    });
+
+    render(<QuickAddExpense tripId={tripId} onAdded={onAdded} lang="en" buttonVariant="inline" />);
+    await user.click(screen.getByRole('button', { name: mockDict.budget.quickAdd.submit }));
+
+    await user.type(screen.getByLabelText(mockDict.budget.quickAdd.amount), '50');
+
+    const submitButton = screen.getByRole('button', { name: mockDict.budget.quickAdd.submit });
+    await user.click(submitButton);
+
+    expect(await screen.findByText('Failed to add expense')).toBeInTheDocument();
+    expect(onAdded).not.toHaveBeenCalled();
+    expect(screen.getByText(mockDict.budget.quickAdd.title)).toBeInTheDocument(); // Dialog stays open
+  });
+
+  it('disables submit button when amount is missing', async () => {
+    render(<QuickAddExpense tripId={tripId} onAdded={onAdded} lang="en" buttonVariant="inline" />);
+    await user.click(screen.getByRole('button', { name: mockDict.budget.quickAdd.submit }));
+
+    const submitButton = screen.getByRole('button', { name: mockDict.budget.quickAdd.submit });
+    expect(submitButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText(mockDict.budget.quickAdd.amount), '10');
+    expect(submitButton).not.toBeDisabled();
+  });
+});


### PR DESCRIPTION
Adds comprehensive tests for the `QuickAddExpense` and `BudgetDashboard` components, significantly improving the repository's test coverage.

This addresses the task of adding meaningful tests to untested parts of the codebase, focusing on the budget-related features.

The new tests cover the following key behaviors and edge cases:

**`tests/components/budget/QuickAddExpense.test.tsx`:**
- Verification of the dialog opening and closing.
- Mocking and verification of asynchronous category fetching.
- Simulation of user input for all form fields.
- Testing the success path, ensuring the `onAdded` callback is fired with the correct payload.
- Testing the failure path, ensuring error messages are displayed.
- Confirming that the submit button is disabled when required fields are empty.

**`tests/components/budget/BudgetDashboard.test.tsx`:**
- Initial data fetching and rendering of the expense list.
- Correct handling of loading and error states during the fetch lifecycle.
- Comprehensive testing of the filtering logic, including budget mode and prepaid status toggles.
- Verification of the expense deletion functionality, including the optimistic UI update.
- Testing the manual refresh button to ensure it re-triggers the data fetch.
- Verification of the optimistic UI update when a new expense is added via the child `QuickAddExpense` component.

Polyfills for `hasPointerCapture` and `scrollIntoView` were added to the test setup to support Radix UI components in the JSDOM environment.